### PR TITLE
feat: support setting quota for hostpath based local PVs

### DIFF
--- a/helm/templates/storage-class.yaml
+++ b/helm/templates/storage-class.yaml
@@ -81,6 +81,23 @@ volumeBindingMode: WaitForFirstConsumer
 # TODO(x.zhou): allow volume expansion
 allowVolumeExpansion: false
 ---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageclass.hostpath.name }}-quota
+  annotations:
+    local.csi.aliyun.com/config: |
+      - name: BasePath
+        value: /var/open-local/local
+      - name: EXT4Quota
+        enabled: true
+{{ include "local.labels" . | indent 2 }}
+provisioner: {{ .Values.driver }}/hostpath
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+# TODO(x.zhou): allow volume expansion
+allowVolumeExpansion: false
+---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:

--- a/pkg/provisioner/config.go
+++ b/pkg/provisioner/config.go
@@ -20,6 +20,7 @@ package provisioner
 import (
 	"context"
 	"slices"
+	"strconv"
 	"strings"
 
 	errors "github.com/pkg/errors"
@@ -200,6 +201,40 @@ func (c *VolumeConfig) GetPath() (string, error) {
 		ValidateAndBuild()
 }
 
+func (c *VolumeConfig) IsXfsQuotaEnabled() bool {
+	xfsQuotaEnabled := c.getEnabled(KeyXFSQuota)
+	xfsQuotaEnabled = strings.TrimSpace(xfsQuotaEnabled)
+
+	enableXfsQuotaBool, err := strconv.ParseBool(xfsQuotaEnabled)
+	// Default case
+	// this means that we have hit either of the two cases below:
+	//     i. The value was something other than a straightforward
+	//        true or false
+	//    ii. The value was empty
+	if err != nil {
+		return false
+	}
+
+	return enableXfsQuotaBool
+}
+
+func (c *VolumeConfig) IsExt4QuotaEnabled() bool {
+	ext4QuotaEnabled := c.getEnabled(KeyEXT4Quota)
+	ext4QuotaEnabled = strings.TrimSpace(ext4QuotaEnabled)
+
+	enableExt4QuotaBool, err := strconv.ParseBool(ext4QuotaEnabled)
+	// Default case
+	// this means that we have hit either of the two cases below:
+	//     i. The value was something other than a straightforward
+	//        true or false
+	//    ii. The value was empty
+	if err != nil {
+		return false
+	}
+
+	return enableExt4QuotaBool
+}
+
 // getValue is a utility function to extract the value
 // of the `key` from the ConfigMap object - which is
 // map[string]interface{map[string][string]}
@@ -325,8 +360,8 @@ func ConfigToMap(all []Config) (m map[string]interface{}, err error) {
 		}
 		confHierarchy := map[string]interface{}{
 			configName: map[string]string{
-				"enable": config.Enabled,
-				"value":  config.Value,
+				"enabled": config.Enabled,
+				"value":   config.Value,
 			},
 		}
 		isMerged := MergeMapOfObjects(m, confHierarchy)

--- a/pkg/provisioner/config.go
+++ b/pkg/provisioner/config.go
@@ -259,6 +259,30 @@ func (c *VolumeConfig) getValue(key string) string {
 	return ""
 }
 
+// Similar to getValue() above. Returns value of the
+// 'Enabled' parameter.
+func (c *VolumeConfig) getEnabled(key string) string {
+	if configObj, ok := GetNestedField(c.options, key).(map[string]string); ok {
+		if val, p := configObj["enabled"]; p {
+			return val
+		}
+	}
+	return ""
+}
+
+// This is similar to getValue() and getEnabled().
+// This gets the value for a specific
+// 'Data' parameter key-value pair.
+func (c *VolumeConfig) getDataField(key string, dataKey string) string {
+	if configData, ok := GetNestedField(c.configData, key).(map[string]string); ok {
+		if val, p := configData[dataKey]; p {
+			return val
+		}
+	}
+	//Default case
+	return ""
+}
+
 // This gets the list of values for the 'List' parameter.
 func (c *VolumeConfig) getList(key string) []string {
 	if listValues, ok := GetNestedField(c.configList, key).([]string); ok {

--- a/pkg/provisioner/helper_hostpath.go
+++ b/pkg/provisioner/helper_hostpath.go
@@ -19,7 +19,11 @@ package provisioner
 
 import (
 	"context"
+	"math"
 	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	errors "github.com/pkg/errors"
@@ -66,6 +70,15 @@ type HelperPodOptions struct {
 	selectedNodeTaints []corev1.Taint
 
 	imagePullSecrets []corev1.LocalObjectReference
+
+	// softLimitGrace is the soft limit of quota on the project
+	softLimitGrace string
+
+	// hardLimitGrace is the hard limit of quota on the project
+	hardLimitGrace string
+
+	// pvcStorage is the storage requested for pv
+	pvcStorage int64
 }
 
 // validate checks that the required fields to launch
@@ -80,6 +93,40 @@ func (pOpts *HelperPodOptions) validate() error {
 		return errors.Errorf("invalid empty name or hostpath or hostname or service account name, %+v", pOpts)
 	}
 	return nil
+}
+
+// converToK converts the limits to kilobytes
+func convertToK(limit string, pvcStorage int64) (string, error) {
+
+	if len(limit) == 0 {
+		return "0k", nil
+	}
+
+	valueRegex := regexp.MustCompile(`[\d]*[\.]?[\d]*`)
+	valueString := valueRegex.FindString(limit)
+
+	if limit != valueString+"%" {
+		return "", errors.Errorf("invalid format for limit grace")
+	}
+
+	value, err := strconv.ParseFloat(valueString, 64)
+
+	if err != nil {
+		return "", errors.Errorf("invalid format, cannot parse")
+	}
+	if value > 100 {
+		value = 100
+	}
+
+	value *= float64(pvcStorage)
+	value /= 100
+	value += float64(pvcStorage)
+	value /= 1024
+
+	value = math.Ceil(value)
+	valueString = strconv.FormatFloat(value, 'f', -1, 64)
+	valueString += "k"
+	return valueString, nil
 }
 
 // createInitPod launches a helper(busybox) pod, to create the host path.
@@ -159,6 +206,105 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 	if err := p.exitPod(ctx, cPod); err != nil {
 		return err
 	}
+	return nil
+}
+
+// validateLimits check that the limits to setup qouta are valid
+func (pOpts *HelperPodOptions) validateLimits() error {
+	if pOpts.softLimitGrace == "0k" &&
+		pOpts.hardLimitGrace == "0k" {
+		// Hack: using convertToK() style converstion
+		// TODO: Refactor this section of the code
+		pvcStorageInK := math.Ceil(float64(pOpts.pvcStorage) / 1024)
+		pvcStorageInKString := strconv.FormatFloat(pvcStorageInK, 'f', -1, 64) + "k"
+		pOpts.softLimitGrace, pOpts.hardLimitGrace = pvcStorageInKString, pvcStorageInKString
+		return nil
+	}
+
+	if pOpts.softLimitGrace == "0k" ||
+		pOpts.hardLimitGrace == "0k" {
+		return nil
+	}
+
+	if len(pOpts.softLimitGrace) > len(pOpts.hardLimitGrace) ||
+		(len(pOpts.softLimitGrace) == len(pOpts.hardLimitGrace) &&
+			pOpts.softLimitGrace > pOpts.hardLimitGrace) {
+		return errors.Errorf("hard limit cannot be smaller than soft limit")
+	}
+
+	return nil
+}
+
+// createQuotaPod launches a helper(busybox) pod, to apply the quota.
+//
+//	The local pv expect the hostpath to be already present before mounting
+//	into pod. Validate that the local pv host path is not created under root.
+func (p *Provisioner) createQuotaPod(ctx context.Context, pOpts *HelperPodOptions) error {
+	var config podConfig
+	config.pOpts, config.podName = pOpts, "quota"
+	// err := pOpts.validate()
+	if err := pOpts.validate(); err != nil {
+		return err
+	}
+
+	// Initialize HostPath builder and validate that
+	// volume directory is not directly under root.
+	// Extract the base path and the volume unique path.
+	var vErr error
+	config.parentDir, config.volumeDir, vErr = hostpath.NewBuilder().WithPath(pOpts.path).
+		WithCheckf(hostpath.IsNonRoot(), "volume directory {%v} should not be under root directory", pOpts.path).
+		ExtractSubPath()
+	if vErr != nil {
+		return vErr
+	}
+
+	// Pass on the taints, to create tolerations.
+	config.taints = pOpts.selectedNodeTaints
+
+	var lErr error
+	config.pOpts.softLimitGrace, lErr = convertToK(config.pOpts.softLimitGrace, config.pOpts.pvcStorage)
+	if lErr != nil {
+		return lErr
+	}
+	config.pOpts.hardLimitGrace, lErr = convertToK(config.pOpts.hardLimitGrace, config.pOpts.pvcStorage)
+	if lErr != nil {
+		return lErr
+	}
+
+	if err := pOpts.validateLimits(); err != nil {
+		return err
+	}
+
+	// fs stores the file system of mount
+	fs := "FS=`stat -f -c %T /data` ; "
+	// check if fs is xfs or ext4 (output of stat is ext2/ext3)
+	// PID is the last project Id in the directory
+	// xfs_quota project(xfs) or chattr +P (ext4) initializes project with new project id
+	// xfs_quota limit(xfs) or repquota (ext4) sets the quota according to limits defined
+	checkQuota := "set -x;" +
+		"if [[ \"$FS\" == \"xfs\" ]]; then " +
+		"  PID=`xfs_quota -x -c 'report -h' /data | tail -2 | awk 'NR==1{print substr ($1,2)}+0'` ;" +
+		"  PID=`expr $PID + 1` ;" +
+		"  xfs_quota -x -c 'project -s -p " + filepath.Join("/data/", config.volumeDir) + " '$PID /data;" +
+		"  xfs_quota -x -c 'limit -p bsoft=" + config.pOpts.softLimitGrace + " bhard=" + config.pOpts.hardLimitGrace + " '$PID /data ;" +
+		"elif [[ \"$FS\" == \"ext2/ext3\" ]]; then" +
+		"  PID=`repquota -P /data | tail -3 | awk 'NR==1{print substr ($1,2)}+0'` ;" +
+		"  PID=`expr $PID + 1` ;" +
+		"  chattr +P -p $PID " + filepath.Join("/data/", config.volumeDir) + " ;" +
+		"  setquota -P $PID " + strings.ToUpper(config.pOpts.softLimitGrace) + " " + strings.ToUpper(config.pOpts.hardLimitGrace) + " 0 0 " + "/data ; " +
+		"else " +
+		"  rm -rf " + filepath.Join("/data/", config.volumeDir) + " ; exit 1; fi"
+	config.pOpts.cmdsForPath = []string{"sh", "-c", fs + checkQuota}
+
+	qPod, err := p.launchPod(ctx, config)
+	if err != nil {
+		return err
+	}
+
+	if err := p.exitPod(ctx, qPod); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -249,6 +395,9 @@ func (p *Provisioner) exitPod(ctx context.Context, hPod *corev1.Pod) error {
 		} else if checkPod.Status.Phase == corev1.PodSucceeded {
 			completed = true
 			break
+		} else if checkPod.Status.Phase == corev1.PodFailed {
+			return errors.Errorf("helper pod is failed, reason: %s, message: %s",
+				checkPod.Status.Reason, checkPod.Status.Message)
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/pkg/provisioner/helper_hostpath.go
+++ b/pkg/provisioner/helper_hostpath.go
@@ -213,7 +213,7 @@ func (p *Provisioner) createCleanupPod(ctx context.Context, pOpts *HelperPodOpti
 func (pOpts *HelperPodOptions) validateLimits() error {
 	if pOpts.softLimitGrace == "0k" &&
 		pOpts.hardLimitGrace == "0k" {
-		// Hack: using convertToK() style converstion
+		// Hack: using convertToK() style conversion
 		// TODO: Refactor this section of the code
 		pvcStorageInK := math.Ceil(float64(pOpts.pvcStorage) / 1024)
 		pvcStorageInKString := strconv.FormatFloat(pvcStorageInK, 'f', -1, 64) + "k"


### PR DESCRIPTION
Using the project quota feature of ext4/xfs, we can limit the data write amount of hostpath local PV to not exceed its requested amount.

How to use:

1. Ensure that the /var/open-local/local directory on the host is a mountpoint, and that its file system has enabled project quota support.

2. Use "open-local-hostpath-quota" StorageClass to create PVC.
```bash
kubectl apply -f - <<-"EOF"
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-localpv-pvc
  annotations:
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
  storageClassName: open-local-hostpath-quota
EOF
```
3. Create a test Pod.
```bash
kubectl apply -f - <<-"EOF"
apiVersion: v1
kind: Pod
metadata:
  name: test-localpv
spec:
  restartPolicy: Never
  containers:
   - name: test
     image: bash:latest
     command:
     - bash
     - -c
     - |
       # should exceed the quota
       dd if=/dev/zero of=/data/bigfile bs=1M count=3000
     volumeMounts:
       - mountPath: /data
         name: dir
  volumes:
   - name: dir
     persistentVolumeClaim:
       claimName: test-localpv-pvc
EOF
```

TODO
* Support volume expansion.
* The method of obtaining the project ID may have concurrency issues, it needs a more reliable way.